### PR TITLE
Skip NEXTAUTH_SECRET and SALT in worker when source values are null.

### DIFF
--- a/charts/langfuse/templates/deployment-worker.yaml
+++ b/charts/langfuse/templates/deployment-worker.yaml
@@ -84,13 +84,17 @@ spec:
             {{- end }}
             - name: NEXTAUTH_URL
               value: {{ .Values.langfuse.nextauth.url | quote }}
+            {{- if .Values.langfuse.nextauth.secret }}
             - name: NEXTAUTH_SECRET
               valueFrom:
                 secretKeyRef:
                   name: {{ include "langfuse.nextauthSecretName" . }}
                   key: nextauth-secret
+            {{- end }}
+            {{- if .Values.langfuse.salt }}
             - name: SALT
               value: {{ .Values.langfuse.salt | quote }}
+            {{- end }}
             - name: TELEMETRY_ENABLED
               value: {{ .Values.langfuse.telemetryEnabled | quote }}
             - name: NEXT_PUBLIC_SIGN_UP_DISABLED


### PR DESCRIPTION
Should fix issue when `NEXTAUTH_SECRET` env is set manually, but the worker still has a dependency on the non-existent `langfuse-nextauth` Secret resource.

Also updated `SALT` as well, since it looked inconsistent with the web Deployment. I don't think this is required, though.